### PR TITLE
Fix adding plugins for CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,6 @@ jobs:
         with:
           release: ${{ matrix.release }}
 
-      # Run script that add additional plugins to environment
-      - name: Add additional plugins
-        uses: matlab-actions/run-command@v1
-        with:
-          command: add_plugins
-
       # Runs a set of commands using the runners shell
       - name: Run all tests
         uses: matlab-actions/run-tests@v1

--- a/add_plugins.m
+++ b/add_plugins.m
@@ -1,13 +1,48 @@
-eeglab;
-try plugin_askinstall('neuroscanio', [], true); catch, disp(lasterror); end;
-try plugin_askinstall('bva-io', [], true); catch, disp(lasterror); end;
-try plugin_askinstall('Biosig', [], true); catch, disp(lasterror); end;
-try plugin_askinstall('Fileio', [], true); catch, disp(lasterror); end;
-try plugin_askinstall('erpssimport', [], true); catch, disp(lasterror); end;
-try plugin_askinstall('Fieldtrip-lite', [], true); catch, disp(lasterror); end;
-try plugin_askinstall('corrmap', [], true); catch, disp(lasterror); end;
-try plugin_askinstall('bdfimport', [], true); catch, disp(lasterror); end;
-try plugin_askinstall('picard', [], true); catch, disp(lasterror); end;
-try plugin_askinstall('bids-matlab-tools', [], true); catch, disp(lasterror); end;
-try plugin_askinstall('LIMO', [], true); catch, disp(lasterror); end;
-try plugin_askinstall('erpssimport', [], true); catch, disp(lasterror); end;
+function add_plugins
+% ADD_PLUGINS adds the necessary plugins (if not yet installed) for running
+% all tests
+
+% run EEGLAB to get access to already installed plugins
+eeglab nogui
+
+try
+    PLUGINLIST = evalin('base', 'PLUGINLIST');
+    installedPlugins = convertCharsToStrings({PLUGINLIST.plugin});
+catch
+    installedPlugins = "";
+end
+
+pluginsToInstall = [
+    "neuroscanio"
+    "bva-io"
+    "Biosig"
+    "Fileio"
+    "erpssimport"
+    "Fieldtrip-lite"
+    "corrmap"
+    "BDFimport"
+    "PICARD"
+    "bids-matlab-tools"
+    "LIMO"
+    "erpssimport"
+    ];
+
+% install each plugins with the install subfunction
+arrayfun(@install, pluginsToInstall);
+
+    function install(plugin)
+        force = true;
+
+        % Only install if it is not yet installed
+        if all(installedPlugins ~= plugin)
+
+            try
+                plugin_askinstall(plugin, [], force)
+            catch exc
+                disp(exc)
+            end
+
+        end
+    end
+
+end

--- a/resources/project/Root.type.EntryPoints/5638398e-cf86-4cf6-9a1b-f58f4c89cffa.type.EntryPoint.xml
+++ b/resources/project/Root.type.EntryPoints/5638398e-cf86-4cf6-9a1b-f58f4c89cffa.type.EntryPoint.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Type="StartUp" Visible="0" Icon="" File="add_plugins.m" Name="add_plugins" />

--- a/resources/project/Root.type.Files/add_plugins.m.type.File.xml
+++ b/resources/project/Root.type.Files/add_plugins.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="other" />
+    </Category>
+</Info>


### PR DESCRIPTION
- Add `add_plugins` to MATLAB project (to allow next step):
- Move `add_plugins` from CI step to MATLAB Project startup
- Only (force) install plugins if not yet installed to prevent long startup times of opening Project
