### PR TITLE
KAN-35 EEGLAB test repo Github actions broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: 
-      group: larger-runner 
       labels: ubuntu-latest-m
     continue-on-error: true
 


### PR DESCRIPTION
Workflow is not able to detect a runner and that's why the job is timing out. 