### PR TITLE
KAN-35 Adding missing toolboxes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{ matrix.release }}
+          products: Statistics_and_Machine_Learning_Toolbox
+          cache: true
           
       # Runs a set of commands using the runner's shell
       - name: Run all tests


### PR DESCRIPTION
Below are the test failures due to missing toolboxes

T-test functions:

    statcondTest/pairedTTest - requires ttest()

    statcondTest/unpairedTTest - requires ttest2()

ANOVA functions:

    statcondTest/paired1Anova - requires fcdf() via rm_anova2()

    statcondTest/paired2Anova - requires fcdf() via rm_anova2()

    statcondTest/unpaired1Anova - requires anova1()

    statcondTest/unpaired2Anova - requires anova2()

Error examples:

text
Undefined function 'ttest' for input arguments of type 'double'.
Undefined function 'anova1' for input arguments of type 'cell'.
Undefined function 'fcdf' for input arguments of type 'double'.

Category 2: Numerical Tolerance Failures (3 failures)

These tests fail due to small numerical differences exceeding the 1% relative tolerance:

    statcondTest/pairedDimTTest: Multiple p-values differ (0.02 vs 0.03, 0.02 vs 0.01)

    statcondTest/unpairedDimTTest: P-value 0.02 vs expected 0.05 (60% error)

    statcondTest/unpairedDim2Anova: P-values with 34.9% and 1.7% relative errors

Category 3: Other Function Failures (3 failures)

    popfunc_pop_eegfilt_wrapperTest/test_test_pop_eegfilt - Errored

    popfunc_pop_eventstat_wrapperTest/test_test_pop_eventstat - Errored

    popfunc_pop_signalstat_wrapperTest/test_test_pop_signalstat - Errored
