### PR TITLE
Fix LFS cache bug causing all binary test failures and multi-hour hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: 
+    runs-on:
       labels: ubuntu-latest-m
     continue-on-error: true
+    timeout-minutes: 120
 
     strategy:
       matrix:
@@ -55,6 +56,9 @@ jobs:
       - name: Git LFS Pull
         if: steps.cache.outputs.cache-hit != 'true'
         run: git lfs pull
+
+      - name: Git LFS Checkout
+        run: git lfs checkout
 
       # Add virtual display support for graphical tests
       - name: Setup Xvfb for virtual display


### PR DESCRIPTION
## Summary

- **Add `git lfs checkout` step** that always runs after LFS cache restore, fixing the root cause of all 12 binary test failures and the multi-hour hang on `binary_pop_snapread_wrapperTest`
- **Add `timeout-minutes: 120`** to the job as a safety net against future hangs

## Root Cause

The CI workflow caches `.git/lfs` and conditionally runs `git lfs pull` only on cache miss. However, `git lfs pull` = `git lfs fetch` + `git lfs checkout`. On cache hit:

1. `.git/lfs/objects` are restored from cache (fetch is unnecessary — good)
2. But `git lfs checkout` (which replaces LFS pointer files in the working tree with actual binary content) **never runs**
3. Working tree files remain as ~130-byte LFS pointer text
4. MATLAB tries to read these as binary → errors (`notBinaryFile`, `nonLogicalConditional`, etc.) or hangs (SMA file reader loops on pointer text)

This caused the **identical 12 test failures** in both R2021b and R2025a jobs, and the hang on `binary_pop_snapread_wrapperTest` that inflated CI runtime from ~1 hour to 4+ hours.

## Test plan

- [ ] Trigger a manual workflow run and verify all 12 previously failing binary tests now pass
- [ ] Verify `binary_pop_snapread_wrapperTest` completes normally instead of hanging
- [ ] Verify total CI runtime returns to ~1 hour range

🤖 Generated with [Claude Code](https://claude.com/claude-code)